### PR TITLE
Add standalone home-manager configurations to flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,14 +63,16 @@
       forAllSystems = lib.genAttrs (import systems);
 
       # nixpkgs settings that used to live in the blueprint call.
+      nixpkgsConfigValues = {
+        allowUnfree = true;
+        allowInsecurePredicate =
+          pkg: (builtins.parseDrvName pkg.name).name == "broadcom-sta";
+      };
+
       nixpkgsConfig =
         { ... }:
         {
-          nixpkgs.config = {
-            allowUnfree = true;
-            allowInsecurePredicate =
-              pkg: (builtins.parseDrvName pkg.name).name == "broadcom-sta";
-          };
+          nixpkgs.config = nixpkgsConfigValues;
         };
 
       # Wire a set of home-manager users ({ name = path; }) into a system
@@ -113,6 +115,32 @@
             (homeUsers users)
           ] ++ modules;
         };
+
+      # Build a standalone home-manager configuration (usable via
+      # `home-manager switch --flake .#<name>`, or buildable directly with
+      # `nix build .#homeConfigurations.<name>.activationPackage`). Unlike the
+      # module wiring above, this does not depend on a surrounding NixOS/Darwin
+      # system, so `osConfig` is absent for these.
+      mkHome =
+        {
+          system,
+          username,
+          homeDirectory,
+          modules,
+        }:
+        home-manager.lib.homeManagerConfiguration {
+          pkgs = import nixpkgs {
+            inherit system;
+            config = nixpkgsConfigValues;
+          };
+          extraSpecialArgs = { inherit inputs; };
+          modules = modules ++ [
+            {
+              home.username = username;
+              home.homeDirectory = homeDirectory;
+            }
+          ];
+        };
     in
     {
       nixosConfigurations = {
@@ -135,6 +163,26 @@
           users = {
             "hawken.rives" = ./hosts/Techcyte-DGQJV434PF/users/hawken.rives.nix;
           };
+        };
+      };
+
+      # Standalone home-manager configurations. The names match the order
+      # `home-manager switch` resolves them in: `<user>@<hostname>` first, then
+      # bare `<user>`. The darwin entry mirrors the work Mac; the bare entry
+      # targets Linux so it can be built/managed in cloud or CI sessions.
+      homeConfigurations = {
+        "hawken.rives@Techcyte-DGQJV434PF" = mkHome {
+          system = "aarch64-darwin";
+          username = "hawken.rives";
+          homeDirectory = "/Users/hawken.rives";
+          modules = [ ./hosts/Techcyte-DGQJV434PF/users/hawken.rives.nix ];
+        };
+
+        "hawken.rives" = mkHome {
+          system = "x86_64-linux";
+          username = "hawken.rives";
+          homeDirectory = "/home/hawken.rives";
+          modules = [ ./hosts/Techcyte-DGQJV434PF/users/hawken.rives.nix ];
         };
       };
 

--- a/modules/home/home-shared.nix
+++ b/modules/home/home-shared.nix
@@ -1,6 +1,9 @@
 {
   pkgs,
-  osConfig,
+  # `osConfig` is only provided when home-manager runs as a NixOS/nix-darwin
+  # module. In a standalone homeConfiguration it is absent, so default to null
+  # and guard any access below.
+  osConfig ? null,
   ...
 }:
 {
@@ -325,8 +328,8 @@
     # TODO: move into separate flakes
     # pkgs.packwiz # for meloncraft-modpack
   ]
-  # you can access the host configuration using `osConfig.`
-  ++ (pkgs.lib.optionals (osConfig.programs.vim.enable && pkgs.stdenv.isDarwin) [ pkgs.skhd ])
+  # you can access the host configuration using `osConfig.` (null when standalone)
+  ++ (pkgs.lib.optionals (osConfig != null && osConfig.programs.vim.enable && pkgs.stdenv.isDarwin) [ pkgs.skhd ])
   ++ (pkgs.lib.optionals (pkgs.stdenv.isDarwin) [ pkgs.cocoapods ])
   ++ (pkgs.lib.optionals (pkgs.stdenv.isLinux) [ ]);
 


### PR DESCRIPTION
## Summary
This PR adds support for standalone home-manager configurations that can be used independently of NixOS/Darwin systems, while also refactoring nixpkgs configuration to reduce duplication.

## Key Changes
- **Extract nixpkgs config**: Moved `nixpkgs.config` settings into a reusable `nixpkgsConfigValues` variable to avoid duplication across system and home-manager configurations
- **Add `mkHome` helper**: Created a new function to build standalone home-manager configurations with proper module wiring and special arguments
- **Add homeConfigurations**: Defined two standalone home-manager configurations:
  - `hawken.rives@Techcyte-DGQJV434PF` for macOS (aarch64-darwin)
  - `hawken.rives` for Linux (x86_64-linux)
- **Update home-shared.nix**: Made `osConfig` optional with a default of `null` to support standalone configurations, and added null-safety checks when accessing `osConfig` properties

## Implementation Details
- The `mkHome` function mirrors the structure of `mkSystem` but uses `home-manager.lib.homeManagerConfiguration` instead of `nixos.lib.nixosSystem`
- Standalone configurations can be used via `home-manager switch --flake .#<name>` or built directly with `nix build .#homeConfigurations.<name>.activationPackage`
- The naming convention follows home-manager's resolution order: `<user>@<hostname>` first, then bare `<user>`
- The `osConfig` parameter is now guarded with `osConfig != null` checks to prevent errors in standalone contexts

https://claude.ai/code/session_018x3t1KRJkZ2P6Mywf9U2ka