### PR TITLE
Export legacyPackages for Home Manager config resolution

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -84,6 +84,11 @@
       templates
       darwinConfigurations
       nixosConfigurations
+      # legacyPackages.<system>.homeConfigurations.<user>@<host> holds the
+      # standalone Home Manager configs Blueprint builds from hosts/*/users/*.nix.
+      # This is what `nh home switch` / `home-manager switch` auto-detect, so it
+      # must be re-exported for `.#<user>@<host>` to resolve.
+      legacyPackages
       modules
       homeModules
       darwinModules


### PR DESCRIPTION
## Summary
Added `legacyPackages` to the flake outputs to enable proper resolution of Home Manager configurations built from `hosts/*/users/*.nix` files.

## Changes
- Exported `legacyPackages` in flake outputs alongside existing exports like `templates`, `darwinConfigurations`, and `nixosConfigurations`
- Added documentation comments explaining that `legacyPackages.<system>.homeConfigurations.<user>@<host>` holds standalone Home Manager configs
- This enables `nh home switch` and `home-manager switch` to auto-detect and resolve `.#<user>@<host>` references

## Details
The `legacyPackages` output was previously not re-exported, which prevented Home Manager from properly discovering configurations. By adding this export, the flake now properly surfaces Home Manager configurations in a location where standard Home Manager tooling expects to find them.

https://claude.ai/code/session_014Eeee7BfEcAt3q5hLqwR4c