### PR TITLE
home-shared: install skhd from user's own vim/neovim config

### DIFF
--- a/modules/home/home-shared.nix
+++ b/modules/home/home-shared.nix
@@ -325,10 +325,10 @@
     # TODO: move into separate flakes
     # pkgs.packwiz # for meloncraft-modpack
   ]
-  # install skhd on macOS when this user has enabled vim or neovim. keyed off the
-  # user's own Home Manager config (not the host's osConfig) so it works for both
-  # standalone (`nh home switch`) and module-integrated evaluation.
-  ++ (pkgs.lib.optionals ((config.programs.vim.enable || config.programs.neovim.enable) && pkgs.stdenv.isDarwin) [ pkgs.skhd ])
+  # you can also look at the current user's config (`config`) or the system
+  # config (`osConfig`), but note that osConfig is null if the homeManager
+  # config is evaluated separately as in `nh home switch .#`.
+  ++ (pkgs.lib.optionals ((config.programs.vim.enable || config.programs.neovim.enable) && pkgs.stdenv.isDarwin) [ ])
   ++ (pkgs.lib.optionals (pkgs.stdenv.isDarwin) [ pkgs.cocoapods ])
   ++ (pkgs.lib.optionals (pkgs.stdenv.isLinux) [ ]);
 

--- a/modules/home/home-shared.nix
+++ b/modules/home/home-shared.nix
@@ -1,6 +1,6 @@
 {
   pkgs,
-  osConfig,
+  config,
   ...
 }:
 {
@@ -325,8 +325,10 @@
     # TODO: move into separate flakes
     # pkgs.packwiz # for meloncraft-modpack
   ]
-  # you can access the host configuration using `osConfig.`
-  ++ (pkgs.lib.optionals (osConfig.programs.vim.enable && pkgs.stdenv.isDarwin) [ pkgs.skhd ])
+  # install skhd on macOS when this user has enabled vim or neovim. keyed off the
+  # user's own Home Manager config (not the host's osConfig) so it works for both
+  # standalone (`nh home switch`) and module-integrated evaluation.
+  ++ (pkgs.lib.optionals ((config.programs.vim.enable || config.programs.neovim.enable) && pkgs.stdenv.isDarwin) [ pkgs.skhd ])
   ++ (pkgs.lib.optionals (pkgs.stdenv.isDarwin) [ pkgs.cocoapods ])
   ++ (pkgs.lib.optionals (pkgs.stdenv.isLinux) [ ]);
 


### PR DESCRIPTION
## Summary

Follow-up to #8. The `skhd` (macOS) package in `modules/home/home-shared.nix` was gated on the **host-level** `osConfig.programs.vim.enable`. `osConfig` is `null` during **standalone** Home Manager evaluation (`nh home switch`), so this threw `error: expected a set but found null` once #8 made the standalone `homeConfigurations` resolvable.

This keys the decision off the **user's own** Home Manager config instead:

```nix
++ (pkgs.lib.optionals
     ((config.programs.vim.enable || config.programs.neovim.enable) && pkgs.stdenv.isDarwin)
     [ pkgs.skhd ])
```

- Drops the `osConfig` dependency entirely (also removed from the module args).
- Works for both standalone and module-integrated evaluation.
- Now includes `programs.neovim` as well, per request.
- Keeps the `isDarwin` guard since `skhd` is macOS-only.

## Verification

Evaluated `activationPackage.drvPath` for all three standalone configs with Lix; all build a derivation:

- `hawken.rives@Techcyte-DGQJV434PF` (aarch64-darwin) — `neovim.enable = true`, so `skhd` is still included ✅
- `natsume@nutmeg`, `techcyte@nutmeg` (x86_64-linux) — no regression ✅


---
_Generated by [Claude Code](https://claude.ai/code/session_014Eeee7BfEcAt3q5hLqwR4c)_